### PR TITLE
Improve role pinging

### DIFF
--- a/terror_zones.py
+++ b/terror_zones.py
@@ -105,7 +105,7 @@ class D2RuneWizardClient():
             response = get(url, params=params, timeout=10)
 
             response.raise_for_status()
-            return response.json().get('terror_zone', {})
+            return response.json().get('terrorZone', {})
         except Exception as err:
             print(f'[D2RW.terror_zone] API Error: {err}')
             return {}


### PR DESCRIPTION
This PR improves role pinging by only pinging the role if it exists on the server. It also simplifies the data returned by `D2RuneWizardClient().terror_zone()` by always returning the `.get('terror_zone')` and handling a possible case where `highestProbabilityZone` doesn't exist.

## Tell me more

With the current design, if a role to ping doesn't exist the discord message contains `@deleted-role`:

<img width="294" alt="Screen Shot 2022-11-09 at 3 38 01 PM" src="https://user-images.githubusercontent.com/590328/200953232-c277ad7e-5599-4751-9f49-8fc4faf6bd2a.png">

This change makes it so that roles are only pinged if they are defined in `tzdict` AND they exist on that server:

Role defined, but doesn't exist OR role not defined:

<img width="298" alt="Screen Shot 2022-11-09 at 3 40 12 PM" src="https://user-images.githubusercontent.com/590328/200953312-25415aaf-086f-4eb1-8cdf-1d71811886f1.png">

Role defined but exists:

<img width="416" alt="Screen Shot 2022-11-09 at 4 14 21 PM" src="https://user-images.githubusercontent.com/590328/200953444-d8af6933-f3eb-4988-90d7-1b99a343dd1e.png">

Note that `terror_zone_message()` now accepts a discord client so that we can call `.get_channel(TZ_DISCORD_CHANNEL_ID).guild.get_role(int(pingid))` to confirm that a role actually exists before adding it to the message.

Additionally I updated `D2RuneWizardClient().terror_zone()` so that it always returns `.get('terror_zone')` (or an empty dict `{}`) since the only other bit of data returned from the API is the `providedBy` this simplifies things quite a bit.