### PR TITLE
Update Terror Zones

### DIFF
--- a/terror_zones.py
+++ b/terror_zones.py
@@ -174,10 +174,10 @@ tzdict = {
         'boss_packs': '10-15',
         'immunities': ['Fire', 'Lightning', 'Cold'],
     },
-    'Jail': {
+    'Jail and Barracks': {
         'pingid': 'ROLE ID',
-        'boss_packs': '18-24',
-        'super_uniques': 'Pitspawn Fouldog',
+        'boss_packs': '24-32',
+        'super_uniques': 'Pitspawn Fouldog and The Smith',
         'immunities': ['Cold', 'Fire', 'Poison', 'Physical'],
     },
     'Kurast Bazaar, Ruined Temple, and Disused Fane': {

--- a/terror_zones.py
+++ b/terror_zones.py
@@ -180,13 +180,6 @@ tzdict = {
         'super_uniques': 'Battlemaid Sarina',
         'immunities': ['Cold', 'Fire', 'Lightning', 'Poison', 'Physical', 'Magic'],
     },
-    'Kurast Sewers': {
-        'pingid': 'ROLE ID',
-        'boss_packs': '12-14',
-        'super_uniques': 'Icehawk Riftwing',
-        'immunities': ['Cold', 'Lightning', 'Poison', 'Magic'],
-        'sparkly_chests': '1',
-    },
     'Lost City, Valley of Snakes, and Claw Viper Temple': {
         'pingid': 'ROLE ID',
         'boss_packs': '21-28',

--- a/terror_zones.py
+++ b/terror_zones.py
@@ -126,11 +126,12 @@ tzdict = {
         'super_uniques': 'Frozenstein',
         'immunities': ['Cold', 'Fire', 'Lightning', 'Poison', 'Physical', 'Magic'],
     },
-    'Dark Wood': {
+    'Dark Wood and Underground Passage': {
         'pingid': 'ROLE ID',
-        'boss_packs': '7-9',
+        'boss_packs': '16-22',
         'super_uniques': 'Treehead Woodfist',
-        'immunities': ['Cold', 'Fire', 'Poison'],
+        'immunities': ['Cold', 'Fire', 'Poison', 'Lightning'],
+        'sparkly_chests': '1',
     },
     'Dry Hills and Halls of the Dead': {
         'pingid': 'ROLE ID',

--- a/terror_zones.py
+++ b/terror_zones.py
@@ -169,6 +169,11 @@ tzdict = {
         'super_uniques': 'Bonesaw Breaker',
         'immunities': ['Cold', 'Fire', 'Lightning', 'Poison', 'Physical'],
     },
+    'Great Marsh': {
+        'pingid': 'ROLE ID',
+        'boss_packs': '10-15',
+        'immunities': ['Fire', 'Lightning', 'Cold'],
+    },
     'Jail': {
         'pingid': 'ROLE ID',
         'boss_packs': '18-24',

--- a/terror_zones.py
+++ b/terror_zones.py
@@ -163,9 +163,9 @@ tzdict = {
         'super_uniques': 'Eldritch the Rectifier, Sharptooth Slayer, and Eyeback the Unleashed',
         'immunities': ['Cold', 'Fire', 'Lightning', 'Poison', 'Physical', 'Magic'],
     },
-    'Glacial Trail': {
+    'Glacial Trail and Drifter Cavern': {
         'pingid': 'ROLE ID',
-        'boss_packs': '7-9',
+        'boss_packs': '13-17',
         'super_uniques': 'Bonesaw Breaker',
         'immunities': ['Cold', 'Fire', 'Lightning', 'Poison', 'Physical'],
     },

--- a/terror_zones.py
+++ b/terror_zones.py
@@ -157,12 +157,6 @@ tzdict = {
         'super_uniques': 'Stormtree and Witch Doctor Endugu',
         'immunities': ['Cold', 'Fire', 'Lightning', 'Poison', 'Physical', 'Magic'],
     },
-    'Frigid Highlands': {
-        'pingid': 'ROLE ID',
-        'boss_packs': '9-11',
-        'super_uniques': 'Eldritch the Rectifier, Sharptooth Slayer, and Eyeback the Unleashed',
-        'immunities': ['Cold', 'Fire', 'Lightning', 'Poison', 'Physical', 'Magic'],
-    },
     'Glacial Trail and Drifter Cavern': {
         'pingid': 'ROLE ID',
         'boss_packs': '13-17',

--- a/terror_zones.py
+++ b/terror_zones.py
@@ -52,6 +52,11 @@ emoji_map = {
 # Bot Dictionary #
 ##################
 tzdict = {
+    'Ancient Tunnels': {
+        'pingid': 'ROLE ID',
+        'boss_packs': '6-8',
+        'immunities': ['Fire', 'Poison', 'Lightning', 'Magic'],
+    },
     'Ancient\'s Way and Icy Cellar': {
         'pingid': 'ROLE ID',
         'boss_packs': '6-8',

--- a/terror_zones.py
+++ b/terror_zones.py
@@ -76,6 +76,12 @@ tzdict = {
         'super_uniques': 'Thresh Socket',
         'immunities': ['Cold', 'Fire', 'Lightning', 'Poison'],
     },
+    'Black Marsh and The Hole': {
+        'pingid': 'ROLE ID',
+        'boss_packs': '15-20',
+        'immunities': ['Fire', 'Cold', 'Lighting', 'Poison'],
+        'sparkly_chests': '1',
+    }
     'Blood Moor and Den of Evil': {
         'pingid': 'ROLE ID',
         'boss_packs': '7-9',

--- a/terror_zones.py
+++ b/terror_zones.py
@@ -81,7 +81,7 @@ tzdict = {
         'boss_packs': '15-20',
         'immunities': ['Fire', 'Cold', 'Lighting', 'Poison'],
         'sparkly_chests': '1',
-    }
+    },
     'Blood Moor and Den of Evil': {
         'pingid': 'ROLE ID',
         'boss_packs': '7-9',

--- a/terror_zones.py
+++ b/terror_zones.py
@@ -88,11 +88,11 @@ tzdict = {
         'super_uniques': 'Corpsefire',
         'immunities': ['Cold', 'Fire'],
     },
-    'Bloody Foothills': {
+    'Bloody Foothills, Frigid Highlands and Abaddon': {
         'pingid': 'ROLE ID',
-        'boss_packs': '4-6',
-        'super_uniques': 'Dac Farren and Shenk The Overseer',
-        'immunities': ['Cold', 'Fire', 'Lightning', 'Poison'],
+        'boss_packs': '19-25',
+        'super_uniques': 'Dac Farren, Shenk The Overseer, Eldritch the Rectifier, Sharptooth Slayer and Eyeback the Unleashed',
+        'immunities': ['Cold', 'Fire', 'Lightning', 'Poison', 'Physical', 'Magic'],
     },
     'Burial Grounds, The Crypt, and The Mausoleum': {
         'pingid': 'ROLE ID',

--- a/terror_zones.py
+++ b/terror_zones.py
@@ -70,9 +70,9 @@ tzdict = {
         'super_uniques': 'The Summoner',
         'immunities': ['Cold', 'Fire', 'Lightning', 'Poison', 'Physical'],
     },
-    'Arreat Plateau': {
+    'Arreat Plateau and Pit of Acheron': {
         'pingid': 'ROLE ID',
-        'boss_packs': '9-11',
+        'boss_packs': '15-19',
         'super_uniques': 'Thresh Socket',
         'immunities': ['Cold', 'Fire', 'Lightning', 'Poison'],
     },


### PR DESCRIPTION
This PR updates the `tzdict` with the current terror zones:
- Adds `Ancient Tunnels`
- Updates `Arreat Plateau` to `Arreat Plateau and Pit of Acheron`
-  Adds `Black Marsh and The Hole`
- Updates `Bloody Foothills` to `Bloody Foothills, Frigid Highlands and Abaddon`
- Updates `Dark Wood` to `Dark Wood and Underground Passage`
- Removes `Frigid Highlands`
- Updates `Glacial Trail` to `Glacial Trail and Drifter Cavern`
- Adds `Great Marsh`
- Updates `Jail` to `Jail and Barracks`
- Removes `Kurast Sewers`