### PR TITLE
Read email from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Configuration is done via environment variables, or you can edit the variables n
 **Required**
  - `TZ_DISCORD_TOKEN`: Token for connecting to Discord, create a bot account with the instructions [here](https://discordpy.readthedocs.io/en/stable/discord.html). Only the `Send Messages` permission is required.
  - `TZ_DISCORD_CHANNEL_ID`: The [channel id](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-) to send messages to.
+ - `TZ_D2RW_TOKEN`: Token for querying the d2runewizard.com Terror Zone API. Request one [here](https://d2runewizard.com/integration).
+ - `TZ_D2RW_CONTACT`: The email address for your d2runewizard.com account.
 
 **Optional**
  - Modify the `pingid` for each zone in `tzdict` if you'd like to ping a Discord role when the current zone changes. The `pingid` should be a string containing the id of the Discord role. In the future we'll support a configuration file to make this easier.

--- a/terror_zones.py
+++ b/terror_zones.py
@@ -347,7 +347,7 @@ class D2RuneWizardClient():
             message += f'Sparkly Chests: {sparkly_chests}\n'
 
         # ping a discord role only if it is defined in tzdict
-        if pingid:
+        if pingid and pingid != 'ROLE ID':
             # verify that the role exists for this server by getting the alert channel,
             # getting the guild (server) that channel belongs to, and then getting
             # the role from that guild.

--- a/terror_zones.py
+++ b/terror_zones.py
@@ -282,9 +282,9 @@ tzdict = {
 
 __version__ = '0.1'
 
-# TZ_DISCORD_TOKEN, TZ_D2RW_TOKEN, and TZ_DISCORD_CHANNEL_ID are required
-if not TZ_DISCORD_TOKEN or not TZ_D2RW_TOKEN or TZ_DISCORD_CHANNEL_ID == 0:
-    print('Please set TZ_DISCORD_TOKEN, TZ_D2RW_TOKEN, and TZ_DISCORD_CHANNEL_ID in your environment.')
+# TZ_DISCORD_TOKEN, TZ_DISCORD_CHANNEL_ID, TZ_D2RW_TOKEN, and TZ_D2RW_CONTACT are required
+if not TZ_DISCORD_TOKEN or TZ_DISCORD_CHANNEL_ID == 0 or not TZ_D2RW_TOKEN or not TZ_D2RW_CONTACT:
+    print('Please set TZ_DISCORD_TOKEN, TZ_DISCORD_CHANNEL_ID, TZ_D2RW_TOKEN, and TZ_D2RW_CONTACT in your environment.')
     exit(1)
 
 

--- a/terror_zones.py
+++ b/terror_zones.py
@@ -31,7 +31,9 @@ TZ_DISCORD_TOKEN = environ.get('TZ_DISCORD_TOKEN')
 TZ_DISCORD_CHANNEL_ID = int(environ.get('TZ_DISCORD_CHANNEL_ID', 0))
 
 # D2RuneWizard API (Required)
+# Token and contact (email address) for d2runewizard.com API, get a token at https://d2runewizard.com/integration
 TZ_D2RW_TOKEN = environ.get('TZ_D2RW_TOKEN')
+TZ_D2RW_CONTACT = environ.get('TZ_D2RW_CONTACT')
 
 # Emoji Mapping, currently uses default Discord Emoji.
 # You can use custom emoji by using the emoji ID, e.g. :emoji_name:
@@ -304,7 +306,7 @@ class D2RuneWizardClient():
             url = 'https://d2runewizard.com/api/terror-zone'
             params = {'token': TZ_D2RW_TOKEN}
             headers = {
-                'D2R-Contact': 'EMAIL',
+                'D2R-Contact': TZ_D2RW_CONTACT,
                 'D2R-Platform': 'Discord',
                 'D2R-Repo': 'https://github.com/Martuck/TZ'
             }


### PR DESCRIPTION
Updates the script to read the `D2R-Contact` header (email address) from the `TZ_D2RW_CONTACT` environment variable like the API token.

Updates documentation to include `TZ_D2RW_TOKEN` and `TZ_D2RW_CONTACT`, the check and error message for required environment variables, and an unrelated change to prevent an error if `pingid` is left at the default `'ROLE ID'` value.