### PR TITLE
Handle unknown terror zones

### DIFF
--- a/terror_zones.py
+++ b/terror_zones.py
@@ -414,7 +414,7 @@ class DiscordClient(discord.Client):
 
         # if the terror zone changed since the last check, send a message to Discord
         if terror_zone and terror_zone != self.d2rw.current_terror_zone:
-            print(f'Terror Zone changed from {self.d2rw.current_terror_zone} to {terror_zone}')
+            print(f'Terror Zone changed from "{self.d2rw.current_terror_zone}" to "{terror_zone}"')
             tz_message = D2RuneWizardClient.terror_zone_message(self)
 
             channel = self.get_channel(TZ_DISCORD_CHANNEL_ID)
@@ -441,7 +441,7 @@ class DiscordClient(discord.Client):
         # this prevents a duplicate message from being sent when the bot starts
         # comment this out if you want the bot to post the current terror zone when it starts
         self.d2rw.current_terror_zone = terror_zone
-        print(f'Initial Terror Zone is {terror_zone}')
+        print(f'Initial Terror Zone is "{terror_zone}"')
 
 
 if __name__ == '__main__':

--- a/terror_zones.py
+++ b/terror_zones.py
@@ -324,11 +324,11 @@ class D2RuneWizardClient():
         # get the currently reported TZ status
         tz_status = D2RuneWizardClient.terror_zone()
         zone = tz_status.get('highestProbabilityZone', {}).get('zone')
-        pingid = tzdict.get(zone).get('pingid')
-        boss_packs = tzdict.get(zone).get('boss_packs')
-        super_uniques = tzdict.get(zone).get('super_uniques')
-        immunities = tzdict.get(zone).get('immunities')
-        sparkly_chests = tzdict.get(zone).get('sparkly_chests')
+        pingid = tzdict.get(zone, {}).get('pingid')
+        boss_packs = tzdict.get(zone, {}).get('boss_packs', 'UNKNOWN')
+        super_uniques = tzdict.get(zone, {}).get('super_uniques', 'UNKNOWN')
+        immunities = tzdict.get(zone, {}).get('immunities')
+        sparkly_chests = tzdict.get(zone, {}).get('sparkly_chests')
 
         # build the message
         message = f'Current Terror Zone: **{zone}**\n\n'


### PR DESCRIPTION
Updates the logic to handle new/unknown terror zones without throwing an exception. If the API ever returns a terror zone not listed in `tzdict` the bot will now post a message like this:

<img width="243" alt="Screenshot 2023-04-05 at 8 21 36 PM" src="https://user-images.githubusercontent.com/590328/230249868-5e8a3e52-a246-4370-8394-62d0d46e71ea.png">

Also adds quotes around the terror zone names in the logs to make things a bit more readable.

Without this unknown terror zones will throw this exception:

```py
Traceback (most recent call last):
  File "/home/azureuser/.local/lib/python3.10/site-packages/discord/ext/tasks/__init__.py", line 125, in _loop
    raise exc
  File "/home/azureuser/.local/lib/python3.10/site-packages/discord/ext/tasks/__init__.py", line 101, in _loop
    await self.coro(*args, **kwargs)
  File "/home/azureuser/TZ/terror_zones.py", line 414, in check_terror_zone
    tz_message = D2RuneWizardClient.terror_zone_message(self)
  File "/home/azureuser/TZ/terror_zones.py", line 323, in terror_zone_message
    pingid = tzdict.get(zone).get('pingid')
```