### PR TITLE
Fix typo, handle no super uniques

### DIFF
--- a/terror_zones.py
+++ b/terror_zones.py
@@ -81,7 +81,7 @@ tzdict = {
     'Black Marsh and The Hole': {
         'pingid': 'ROLE ID',
         'boss_packs': '15-20',
-        'immunities': ['Fire', 'Cold', 'Lighting', 'Poison'],
+        'immunities': ['Fire', 'Cold', 'Lightning', 'Poison'],
         'sparkly_chests': '1',
     },
     'Blood Moor and Den of Evil': {

--- a/terror_zones.py
+++ b/terror_zones.py
@@ -334,7 +334,7 @@ class D2RuneWizardClient():
 
         # build the message
         message = f'Current Terror Zone: **{zone}**\n\n'
-        if super_uniques:
+        if super_uniques and super_uniques != 'UNKNOWN':
             message += f'Super Uniques: {super_uniques}\n'
         message += f'Boss Packs: {boss_packs}\n'
 

--- a/terror_zones.py
+++ b/terror_zones.py
@@ -334,7 +334,8 @@ class D2RuneWizardClient():
 
         # build the message
         message = f'Current Terror Zone: **{zone}**\n\n'
-        message += f'Super Uniques: {super_uniques}\n'
+        if super_uniques:
+            message += f'Super Uniques: {super_uniques}\n'
         message += f'Boss Packs: {boss_packs}\n'
 
         # Add emoji Immunities


### PR DESCRIPTION
This PR fixes a `Lightning` immunity typo and gets rid of the `Super Uniques: UNKNOWN` output for zones with no super uniques.