### PR TITLE
Handle rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 A Discord bot for reporting Diablo 2: Resurrected [Terror Zone](https://d2runewizard.com/terror-zone-tracker) changes. By default it will report the terror zone, super uniques, boss packs, immunities, and super chests every hour when the Terror Zone changes.
 
-You can also get the current terror zone by typing `.tz` or `!tz` in chat.
-
 ## Usage
 
 Requires Python 3.8+, tested on Ubuntu 22.04.

--- a/terror_zones.py
+++ b/terror_zones.py
@@ -418,18 +418,6 @@ class DiscordClient(discord.Client):
         except RuntimeError as err:
             print(f'Background Task Error: {err}')
 
-    async def on_message(self, message):
-        """
-        This is called any time the bot receives a message. It implements the tz chatop.
-        """
-        if message.content.startswith('.tz') or message.content.startswith('!tz'):
-            print(f'Responding to TZ chatop from {message.author}')
-            tz_status = await self.d2rw.terror_zone()
-            current_status = D2RuneWizardClient.terror_zone_message(self, tz_status)
-
-            channel = self.get_channel(message.channel.id)
-            await channel.send(current_status)
-
     @tasks.loop(seconds=60)
     async def check_terror_zone(self):
         """

--- a/terror_zones.py
+++ b/terror_zones.py
@@ -16,6 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+from asyncio import sleep as async_sleep
 from os import environ, path
 from requests import get
 from discord.ext import tasks
@@ -461,6 +462,7 @@ class DiscordClient(discord.Client):
         # comment this out if you want the bot to post the current terror zone when it starts
         self.d2rw.current_terror_zone = terror_zone
         print(f'Initial Terror Zone is "{terror_zone}"')
+        await async_sleep(60)
 
 
 if __name__ == '__main__':

--- a/terror_zones.py
+++ b/terror_zones.py
@@ -330,12 +330,15 @@ class D2RuneWizardClient():
             return {}
 
     @staticmethod
-    def terror_zone_message(discord_client):
+    def terror_zone_message(discord_client, tz_status):
         """
         Returns a formatted message of the current terror zone status.
+
+        :param: discord_client: The discord client object
+        :param: tz_status: The current TZ status
+
+        :return: The formatted message for Discord
         """
-        # get the currently reported TZ status
-        tz_status = D2RuneWizardClient.terror_zone()
         zone = tz_status.get('highestProbabilityZone', {}).get('zone')
         pingid = tzdict.get(zone, {}).get('pingid')
         boss_packs = tzdict.get(zone, {}).get('boss_packs', 'UNKNOWN')
@@ -413,7 +416,7 @@ class DiscordClient(discord.Client):
         """
         if message.content.startswith('.tz') or message.content.startswith('!tz'):
             print(f'Responding to TZ chatop from {message.author}')
-            current_status = D2RuneWizardClient.terror_zone_message(self)
+            current_status = D2RuneWizardClient.terror_zone_message(self, self.d2rw.terror_zone())
 
             channel = self.get_channel(message.channel.id)
             await channel.send(current_status)
@@ -425,12 +428,13 @@ class DiscordClient(discord.Client):
         If the current status is different from the last known status, a message is sent to Discord.
         """
         # print('>> Checking Terror Zone status...')
-        terror_zone = self.d2rw.terror_zone().get('highestProbabilityZone', {}).get('zone')
+        tz_status = self.d2rw.terror_zone()
+        terror_zone = tz_status.get('highestProbabilityZone', {}).get('zone')
 
         # if the terror zone changed since the last check, send a message to Discord
         if terror_zone and terror_zone != self.d2rw.current_terror_zone:
             print(f'Terror Zone changed from "{self.d2rw.current_terror_zone}" to "{terror_zone}"')
-            tz_message = D2RuneWizardClient.terror_zone_message(self)
+            tz_message = D2RuneWizardClient.terror_zone_message(self, tz_status)
 
             channel = self.get_channel(TZ_DISCORD_CHANNEL_ID)
             await channel.send(tz_message)


### PR DESCRIPTION
The bot is currently returning this every time the terror zone changes:

> Current Terror Zone: **None**
> 
> Boss Packs: UNKNOWN
> 
> > Data courtesy of d2runewizard.com

This is happening because d2runewizard just started enforcing the API rate limiting (one call every 60 seconds) and `terror_zone_message()` was calling `terror_zone()` so we were making two API calls instead of one, and there was no rate limit handling.

This PR resolves that by:
- Passing the output of `terror_zone()` to `terror_zone_message()`, this makes a single API call instead of two.
- Adding an async sleep of 60 seconds after bot starts and loads the initial terror zone.
- Makes `terror_zone()` async so it can handle rate limiting with an `asyncio.sleep()`--while `time.sleep()` would work it blocks CTRL+C.
- Removes the `!tz` / `.tz` chatop, in the current implementation this will almost certainly cause rate limiting issues. Since the terror zone is posted every time it changes I think this is fine.

If you step through this PR one commit at a time it should be pretty easy to follow.